### PR TITLE
fix missing SMNen definition from compressor struct in tmats types header

### DIFF
--- a/Trunk/TMATS_Library/MEX/types_TMATS.h
+++ b/Trunk/TMATS_Library/MEX/types_TMATS.h
@@ -86,6 +86,7 @@ struct CompressorStruct {
     double EffDes;
     double RlineDes;
     double IDes;
+    double SMNEn;
     double CustBldEn;
     double FBldEn;
     double CustBldNm;


### PR DESCRIPTION
Hey Jeff,

This should fix the problem. I saw the same issue during build, was able to fix by adding a variable definition. For once, I think this is not the fault of the tlc stuff. After adding the fix in, was able to get through the build successfully and run an example.

Let me know if you have any other issues.

Thx,

George